### PR TITLE
Restringe productos de pedidos por empresa

### DIFF
--- a/inventario/funciones.py
+++ b/inventario/funciones.py
@@ -1,16 +1,27 @@
 #----------------------------FUNCIONES DE AYUDA Y COMPLEMENTO--------------------------------------------------
 
+from django.shortcuts import get_object_or_404
+
 from .models import Producto
 
 
-def obtenerIdProducto(descripcion):
-    id_producto = Producto.objects.get(descripcion=descripcion)
+def obtenerIdProducto(descripcion, empresa):
+    """Devuelve el ID del producto filtrando por empresa."""
+
+    empresa_id = getattr(empresa, 'id', empresa)
+    id_producto = Producto.objects.filter(
+        descripcion=descripcion,
+        empresa_id=empresa_id,
+    ).get()
     resultado = id_producto.id
 
     return resultado
 
-def obtenerProducto(idProducto):
-    producto = Producto.objects.get(id=idProducto)
+def obtenerProducto(idProducto, empresa):
+    """Obtiene el producto filtrando por la empresa proporcionada."""
+
+    empresa_id = getattr(empresa, 'id', empresa)
+    producto = get_object_or_404(Producto, id=idProducto, empresa_id=empresa_id)
     return producto
 
 

--- a/inventario/tests/__init__.py
+++ b/inventario/tests/__init__.py
@@ -1,0 +1,2 @@
+"""Test package for inventario app."""
+

--- a/inventario/tests/test_multi_tenant_isolation.py
+++ b/inventario/tests/test_multi_tenant_isolation.py
@@ -1,9 +1,19 @@
 import json
+import os
+from decimal import Decimal
+
+import django
 import pytest
 from django.urls import reverse
 from django.contrib.auth import get_user_model
 from django.test import Client
 from django.core import signing
+
+from django.contrib.messages import get_messages
+
+os.environ.setdefault('DATABASE_URL', 'sqlite:///test_db.sqlite3')
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'sistema.settings')
+django.setup()
 
 from inventario.models import (
     Empresa,
@@ -15,6 +25,9 @@ from inventario.models import (
     Factura,
     Almacen,
     Proforma,
+    Proveedor,
+    Pedido,
+    DetallePedido,
 )
 
 User = get_user_model()
@@ -168,4 +181,127 @@ class TestMultiTenantIsolation:
         # Consulta correcta
         resp2 = client.post(reverse('inventario:consultar_estado_sri', args=[factura.id]))
         assert resp2.status_code == 200
+
+    def test_detalles_pedido_usa_producto_empresa_activa(self, client, usuario, empresas):
+        self._login(client, usuario)
+        empresa_a, empresa_b = empresas
+        proveedor = Proveedor.objects.create(
+            empresa=empresa_a,
+            tipoIdentificacion='05',
+            identificacion_proveedor='9999999999',
+            razon_social_proveedor='Proveedor A',
+            nombre_comercial_proveedor='Proveedor A',
+            direccion='Dir 1',
+            telefono='123456789',
+            correo='prov@a.com',
+        )
+        producto_a = Producto.objects.create(
+            empresa=empresa_a,
+            codigo='PA-1',
+            codigo_barras='111',
+            descripcion='Duplicado',
+            precio=Decimal('10.00'),
+            precio2=Decimal('10.00'),
+            disponible=5,
+            categoria='1',
+            iva='2',
+            costo_actual=Decimal('5.00'),
+        )
+        Producto.objects.create(
+            empresa=empresa_b,
+            codigo='PB-1',
+            codigo_barras='222',
+            descripcion='Duplicado',
+            precio=Decimal('10.00'),
+            precio2=Decimal('10.00'),
+            disponible=5,
+            categoria='1',
+            iva='2',
+            costo_actual=Decimal('5.00'),
+        )
+
+        self._set_empresa(client, empresa_a.id)
+        session = client.session
+        session['form_details'] = 1
+        session['id_proveedor'] = proveedor.identificacion_proveedor
+        session.save()
+
+        response = client.post(
+            reverse('inventario:detallesPedido'),
+            data={
+                'form-TOTAL_FORMS': '1',
+                'form-INITIAL_FORMS': '0',
+                'form-MAX_NUM_FORMS': '',
+                'form-0-descripcion': str(producto_a.id),
+                'form-0-cantidad': '2',
+                'form-0-valor_subtotal': '20.00',
+            },
+        )
+
+        assert response.status_code == 302
+        pedido = Pedido.objects.filter(empresa=empresa_a).latest('id')
+        detalle = DetallePedido.objects.get(id_pedido=pedido)
+        assert detalle.id_producto == producto_a
+
+    def test_detalles_pedido_rechaza_producto_otro_tenant(self, client, usuario, empresas):
+        self._login(client, usuario)
+        empresa_a, empresa_b = empresas
+        proveedor = Proveedor.objects.create(
+            empresa=empresa_a,
+            tipoIdentificacion='05',
+            identificacion_proveedor='1231231231',
+            razon_social_proveedor='Proveedor A',
+            nombre_comercial_proveedor='Proveedor A',
+            direccion='Dir 1',
+            telefono='123456789',
+            correo='prov@a.com',
+        )
+        producto_a = Producto.objects.create(
+            empresa=empresa_a,
+            codigo='PA-2',
+            codigo_barras='333',
+            descripcion='Producto A',
+            precio=Decimal('5.00'),
+            precio2=Decimal('5.00'),
+            disponible=5,
+            categoria='1',
+            iva='2',
+            costo_actual=Decimal('2.00'),
+        )
+        producto_b = Producto.objects.create(
+            empresa=empresa_b,
+            codigo='PB-2',
+            codigo_barras='444',
+            descripcion='Producto A',
+            precio=Decimal('5.00'),
+            precio2=Decimal('5.00'),
+            disponible=5,
+            categoria='1',
+            iva='2',
+            costo_actual=Decimal('2.00'),
+        )
+
+        self._set_empresa(client, empresa_a.id)
+        session = client.session
+        session['form_details'] = 1
+        session['id_proveedor'] = proveedor.identificacion_proveedor
+        session.save()
+
+        response = client.post(
+            reverse('inventario:detallesPedido'),
+            data={
+                'form-TOTAL_FORMS': '1',
+                'form-INITIAL_FORMS': '0',
+                'form-MAX_NUM_FORMS': '',
+                'form-0-descripcion': str(producto_b.id),
+                'form-0-cantidad': '1',
+                'form-0-valor_subtotal': '5.00',
+            },
+        )
+
+        assert response.status_code == 400
+        storage = get_messages(response.wsgi_request)
+        messages_text = [m.message for m in storage]
+        assert any('no pertenecen a la empresa activa' in m.lower() for m in messages_text)
+        assert Pedido.objects.filter(empresa=empresa_a).count() == 0
 

--- a/inventario/views.py
+++ b/inventario/views.py
@@ -3830,27 +3830,43 @@ class DetallesPedido(LoginRequiredMixin, View):
             cantidad = []
             subtotal = []
             total_general = []
-            sub_monto = 0
-            monto_general = 0
+            productos_cache = {}
+            sub_monto = Decimal('0')
+            monto_general = Decimal('0')
 
             for form in formset:
-                desc = form.cleaned_data['descripcion'].descripcion
-                cant = form.cleaned_data['cantidad']
-                sub = form.cleaned_data['valor_subtotal']
+                producto_seleccionado = form.cleaned_data.get('descripcion')
+                cant = form.cleaned_data.get('cantidad')
+                sub = form.cleaned_data.get('valor_subtotal')
 
-                id_producto.append(
-                    obtenerIdProducto(desc))  #esta funcion, a estas alturas, es innecesaria porque ya tienes la id
+                if producto_seleccionado is None:
+                    continue
+
+                try:
+                    producto_validado = productos_cache[producto_seleccionado.id]
+                except KeyError:
+                    try:
+                        producto_validado = obtenerProducto(producto_seleccionado.id, empresa_id)
+                    except Http404:
+                        messages.error(request, 'El producto seleccionado no pertenece a la empresa activa.')
+                        contexto = {'formset': formset}
+                        contexto = complementarContexto(contexto, request.user)
+                        return render(
+                            request,
+                            'inventario/pedido/detallesPedido.html',
+                            contexto,
+                            status=400,
+                        )
+                    productos_cache[producto_seleccionado.id] = producto_validado
+
+                id_producto.append(producto_validado.id)
                 cantidad.append(cant)
                 subtotal.append(sub)
 
-                #Ingresa la factura
-            #--Saca el sub-monto
-            for index in subtotal:
-                sub_monto += index
+            sub_monto = sum(subtotal, Decimal('0'))
 
-            #--Saca el monto general
             for index, element in enumerate(subtotal):
-                producto = obtenerProducto(id_producto[index])
+                producto = productos_cache[id_producto[index]]
                 porcentaje = Decimal(str(producto.get_porcentaje_iva_real())) / 100
                 nuevoPrecio = element + (element * porcentaje)
                 monto_general += nuevoPrecio
@@ -3873,14 +3889,23 @@ class DetallesPedido(LoginRequiredMixin, View):
             id_pedido = pedido
 
             for indice, elemento in enumerate(id_producto):
-                objetoProducto = obtenerProducto(elemento)
+                objetoProducto = productos_cache[elemento]
                 cantidadDetalle = cantidad[indice]
                 subDetalle = subtotal[indice]
                 totalDetalle = total_general[indice]
 
                 # Validar que el producto pertenezca a la misma empresa
                 if hasattr(objetoProducto, 'empresa_id') and objetoProducto.empresa_id != empresa_id:
-                    raise ValueError(f"Producto {objetoProducto.id} no pertenece a la empresa activa")
+                    messages.error(request, 'El producto seleccionado no pertenece a la empresa activa.')
+                    contexto = {'formset': formset}
+                    contexto = complementarContexto(contexto, request.user)
+                    pedido.delete()
+                    return render(
+                        request,
+                        'inventario/pedido/detallesPedido.html',
+                        contexto,
+                        status=400,
+                    )
                 detallePedido = DetallePedido(
                     id_pedido=id_pedido,
                     id_producto=objetoProducto,
@@ -3893,6 +3918,22 @@ class DetallesPedido(LoginRequiredMixin, View):
 
             messages.success(request, 'Pedido de ID %s insertado exitosamente.' % id_pedido.id)
             return HttpResponseRedirect("/inventario/agregarPedido")
+
+        else:
+            status_code = 200
+            for form in formset:
+                if 'descripcion' in form.errors:
+                    messages.error(request, 'Uno o más productos no pertenecen a la empresa activa.')
+                    status_code = 400
+                    break
+            contexto = {'formset': formset}
+            contexto = complementarContexto(contexto, request.user)
+            return render(
+                request,
+                'inventario/pedido/detallesPedido.html',
+                contexto,
+                status=status_code,
+            )
 
         #Fin de vista-----------------------------------------------------------------------------------#
 


### PR DESCRIPTION
## Summary
- filtra `obtenerIdProducto` y `obtenerProducto` por empresa para evitar cruces entre tenants
- reutiliza el producto del formulario al generar pedidos y mejora la respuesta ante productos ajenos a la empresa activa
- configura los tests multi-tenant para usar settings de Django y agrega coberturas para descripciones duplicadas y rechazos cross-tenant

## Testing
- `pytest inventario/tests/test_multi_tenant_isolation.py -k detalles --maxfail=1` *(falla: migraciones con SQL específico de PostgreSQL no son compatibles con SQLite en este entorno)*

------
https://chatgpt.com/codex/tasks/task_e_68caddf309a48325aee0772e233a7d17